### PR TITLE
Add PostgreSQL SSL and authentication database configuration

### DIFF
--- a/pkg/backup.go
+++ b/pkg/backup.go
@@ -460,7 +460,7 @@ func listDatabases(db dbConfig) ([]string, error) {
 		return databases, errors.New(err.Error())
 	}
 	// Construct the connection string
-	connString := fmt.Sprintf("postgres://%s:%s@%s:%s/postgres?sslmode=%s", db.dbUserName, db.dbPassword, db.dbHost, db.dbPort, db.dbSslMode)
+	connString := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s", db.dbUserName, db.dbPassword, db.dbHost, db.dbPort, db.dbAuthDatabase, db.dbSslMode)
 
 	// Connect to the PostgreSQL server
 	conn, err := pgx.Connect(context.Background(), connString)

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -53,6 +53,7 @@ func initDbConfig(cmd *cobra.Command) *dbConfig {
 	dConf.dbUserName = os.Getenv("DB_USERNAME")
 	dConf.dbPassword = os.Getenv("DB_PASSWORD")
 	dConf.dbSslMode = utils.EnvWithDefault("DB_SSL_MODE", defaultSslMode)
+	dConf.dbAuthDatabase = utils.EnvWithDefault("DB_AUTH_DATABASE", defaultAuthDbName)
 
 	err := utils.CheckEnvVars(dbHVars)
 	if err != nil {
@@ -70,13 +71,15 @@ func getDatabase(database Database) *dbConfig {
 	database.Host = goutils.ReplaceEnvVars(getEnvOrDefault(database.Host, "DB_HOST", database.Name, ""))
 	database.Port = goutils.ReplaceEnvVars(getEnvOrDefault(database.Port, "DB_PORT", database.Name, defaultDbPort))
 	database.SslMode = goutils.ReplaceEnvVars(getEnvOrDefault(database.SslMode, "DB_SSL_MODE", database.Name, defaultSslMode))
-	database.AuthDatabase = goutils.ReplaceEnvVars(getEnvOrDefault(database.AuthDatabase, "DB_AUTH_DATABASE", database.Name, defaultSslMode))
+	database.AuthDatabase = goutils.ReplaceEnvVars(getEnvOrDefault(database.AuthDatabase, "DB_AUTH_DATABASE", database.Name, defaultAuthDbName))
 	return &dbConfig{
-		dbHost:     database.Host,
-		dbPort:     database.Port,
-		dbName:     database.Name,
-		dbUserName: database.User,
-		dbPassword: database.Password,
+		dbHost:         database.Host,
+		dbPort:         database.Port,
+		dbName:         database.Name,
+		dbUserName:     database.User,
+		dbPassword:     database.Password,
+		dbSslMode:      database.SslMode,
+		dbAuthDatabase: database.AuthDatabase,
 	}
 }
 
@@ -287,12 +290,13 @@ func initTargetDbConfig() *targetDbConfig {
 			logger.Fatal("Error", "error", err.Error())
 		}
 		return &targetDbConfig{
-			targetDbHost:     config.dbHost,
-			targetDbPort:     config.dbPort,
-			targetDbName:     config.dbName,
-			targetDbPassword: config.dbPassword,
-			targetDbUserName: config.dbUserName,
-			targetDbSslMode:  config.dbSslMode,
+			targetDbHost:         config.dbHost,
+			targetDbPort:         config.dbPort,
+			targetDbName:         config.dbName,
+			targetDbPassword:     config.dbPassword,
+			targetDbUserName:     config.dbUserName,
+			targetDbSslMode:      config.dbSslMode,
+			targetDbAuthDatabase: utils.EnvWithDefault("TARGET_DB_AUTH_DATABASE", defaultAuthDbName),
 		}
 	}
 	tdbConfig := targetDbConfig{}
@@ -302,6 +306,7 @@ func initTargetDbConfig() *targetDbConfig {
 	tdbConfig.targetDbUserName = os.Getenv("TARGET_DB_USERNAME")
 	tdbConfig.targetDbPassword = os.Getenv("TARGET_DB_PASSWORD")
 	tdbConfig.targetDbSslMode = utils.EnvWithDefault("TARGET_DB_SSL_MODE", defaultSslMode)
+	tdbConfig.targetDbAuthDatabase = utils.EnvWithDefault("TARGET_DB_AUTH_DATABASE", defaultAuthDbName)
 
 	err := utils.CheckEnvVars(tdbRVars)
 	if err != nil {

--- a/pkg/helper.go
+++ b/pkg/helper.go
@@ -80,7 +80,7 @@ func testDatabaseConnection(db *dbConfig) error {
 	// Set database name for notification error
 	utils.DatabaseName = db.dbName
 	if db.dbName == "" {
-		connString = fmt.Sprintf("postgres://%s:%s@%s:%s/postgres?sslmode=%s", db.dbUserName, db.dbPassword, db.dbHost, db.dbPort, db.dbSslMode)
+		connString = fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s", db.dbUserName, db.dbPassword, db.dbHost, db.dbPort, db.dbAuthDatabase, db.dbSslMode)
 	}
 
 	// Attempt to connect to the PostgreSQL server
@@ -225,12 +225,23 @@ func convertJDBCToDbConfig(jdbcURI string) (*dbConfig, error) {
 		return &dbConfig{}, fmt.Errorf("incomplete JDBC URI: missing host, database, or username")
 	}
 
+	authDb := os.Getenv("DB_AUTH_DATABASE")
+	if authDb == "" {
+		authDb = defaultAuthDbName
+	}
+	sslMode := os.Getenv("DB_SSL_MODE")
+	if sslMode == "" {
+		sslMode = defaultSslMode
+	}
+
 	return &dbConfig{
-		dbHost:     host,
-		dbPort:     port,
-		dbName:     database,
-		dbUserName: username,
-		dbPassword: password,
+		dbHost:         host,
+		dbPort:         port,
+		dbName:         database,
+		dbUserName:     username,
+		dbPassword:     password,
+		dbSslMode:      sslMode,
+		dbAuthDatabase: authDb,
 	}, nil
 }
 

--- a/pkg/migrate.go
+++ b/pkg/migrate.go
@@ -125,7 +125,7 @@ func migrateAllDatabases(dbConf, targetDb *dbConfig) {
 
 func (db *dbConfig) databaseExists() (bool, error) {
 	adminDb := *db
-	adminDb.dbName = "postgres" // Connect to default "postgres"
+	adminDb.dbName = db.dbAuthDatabase
 	dbConn, err := dbConnect(&adminDb)
 	if err != nil {
 		return false, fmt.Errorf("error connecting to the database: %w", err)
@@ -149,7 +149,7 @@ func (db *dbConfig) databaseExists() (bool, error) {
 
 func (db *dbConfig) createDatabase() error {
 	adminDb := *db
-	adminDb.dbName = "postgres" // Connect to default "postgres" database to create a new one
+	adminDb.dbName = db.dbAuthDatabase
 
 	dbConn, err := dbConnect(&adminDb)
 	if err != nil {

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -26,13 +26,14 @@ package pkg
 
 type StorageType string
 type Database struct {
-	Host     string `yaml:"host"`
-	Port     string `yaml:"port"`
-	Name     string `yaml:"name"`
-	User     string `yaml:"user"`
-	Password string `yaml:"password"`
-	Path     string `yaml:"path"`
-	SslMode  string `yaml:"sslMode"`
+	Host         string `yaml:"host"`
+	Port         string `yaml:"port"`
+	Name         string `yaml:"name"`
+	User         string `yaml:"user"`
+	Password     string `yaml:"password"`
+	Path         string `yaml:"path"`
+	SslMode      string `yaml:"sslMode"`
+	AuthDatabase string `yaml:"authDatabase"`
 }
 type Config struct {
 	CronExpression   string     `yaml:"cronExpression"`
@@ -41,20 +42,22 @@ type Config struct {
 }
 
 type dbConfig struct {
-	dbHost     string
-	dbPort     string
-	dbName     string
-	dbUserName string
-	dbPassword string
-	dbSslMode  string
+	dbHost         string
+	dbPort         string
+	dbName         string
+	dbUserName     string
+	dbPassword     string
+	dbSslMode      string
+	dbAuthDatabase string
 }
 type targetDbConfig struct {
-	targetDbHost     string
-	targetDbPort     string
-	targetDbUserName string
-	targetDbPassword string
-	targetDbName     string
-	targetDbSslMode  string
+	targetDbHost         string
+	targetDbPort         string
+	targetDbUserName     string
+	targetDbPassword     string
+	targetDbName         string
+	targetDbSslMode      string
+	targetDbAuthDatabase string
 }
 type TgConfig struct {
 	Token  string

--- a/pkg/var.go
+++ b/pkg/var.go
@@ -29,12 +29,13 @@ import (
 )
 
 const (
-	tmpPath        = "/tmp/backup"
-	gpgHome        = "/config/gnupg"
-	gpgExtension   = "gpg"
-	timeFormat     = "2006-01-02 at 15:04:05"
-	defaultDbPort  = "5432"
-	defaultSslMode = "disable"
+	tmpPath           = "/tmp/backup"
+	gpgHome           = "/config/gnupg"
+	gpgExtension      = "gpg"
+	timeFormat        = "2006-01-02 at 15:04:05"
+	defaultDbPort     = "5432"
+	defaultSslMode    = "disable"
+	defaultAuthDbName = "postgres"
 )
 
 var (


### PR DESCRIPTION
### Summary

  Adds support for configurable SSL mode and authentication database for PostgreSQL connections.

  ### Changes

  - Add DB_SSL_MODE and TARGET_DB_SSL_MODE environment variables (default: disable)
  - Add DB_AUTH_DATABASE and TARGET_DB_AUTH_DATABASE environment variables (default: postgres)
  - Update all connection strings to use configurable values instead of hardcoded sslmode=disable and postgres database
  - Affects: pkg/backup.go, pkg/config.go, pkg/helper.go, pkg/migrate.go, pkg/types.go, pkg/var.go

  ### Compatibility

   Fully backward compatible - defaults preserve existing behavior