### PR TITLE
Add --exclude-db flag to backup command

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -58,4 +58,5 @@ func init() {
 	BackupCmd.PersistentFlags().Bool("schema-only", false, "Backup database schema only")
 	BackupCmd.PersistentFlags().Bool("data-only", false, "Backup database data only")
 	BackupCmd.PersistentFlags().StringSliceP("tables", "t", []string{}, "List of tables to include in the backup")
+	BackupCmd.PersistentFlags().StringSlice("exclude-db", []string{}, "Databases to exclude from backup (e.g. `--exclude-db _aiven,defaultdb`)")
 }

--- a/docs/how-tos/backup-all.md
+++ b/docs/how-tos/backup-all.md
@@ -59,3 +59,17 @@ docker run --rm --network your_network_name \
 
 - Use `--all-in-one` if you want a quick, simple backup for disaster recovery where you'll restore everything at once.
 - Use `--all-databases` if you need granularity in restoring specific databases or tables without affecting others.
+
+## Excluding Databases
+
+When using `--all-databases`, you can exclude specific databases with the `--exclude-db` flag (comma-separated list).
+
+```bash
+docker run --rm --network your_network_name \
+  -v $PWD/backup:/backup/ \
+  -e "DB_HOST=dbhost" \
+  -e "DB_PORT=5432" \
+  -e "DB_USERNAME=username" \
+  -e "DB_PASSWORD=password" \
+  jkaninda/pg-bkup backup --all-databases --exclude-db _aiven,defaultdb
+```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -12,25 +12,26 @@ Backup, restore, and migration targets, schedules, and retention policies are co
 
 ## CLI Utility Usage
 
-| Option                  | Short Flag | Description                                                                             |
-|-------------------------|------------|-----------------------------------------------------------------------------------------|
-| `pg-bkup`               | `bkup`     | CLI utility for managing PostgreSQL backups.                                            |
-| `backup`                |            | Perform a backup operation.                                                             |
-| `restore`               |            | Perform a restore operation.                                                            |
-| `migrate`               |            | Migrate a database from one instance to another.                                        |
-| `--storage`             | `-s`       | Storage type (`local`, `s3`, `ssh`, etc.). Default: `local`.                            |
-| `--file`                | `-f`       | File name for restoration.                                                              |
-| `--path`                |            | Path for storage (e.g., `/custom_path` for S3 or `/home/foo/backup` for SSH).           |
-| `--config`              | `-c`       | Configuration file for multi database backup. (e.g: `/backup/config.yaml`).             |
-| `--dbname`              | `-d`       | Database name.                                                                          |
-| `--port`                | `-p`       | Database port. Default: `5432`.                                                         |
-| `--disable-compression` |            | Disable compression for database backups.                                               |
-| `--cron-expression`     | `-e`       | Cron expression for scheduled backups (e.g., `0 0 * * *` or `@daily`).                  |
-| `--all-databases`       | `-a`       | Backs up all databases separately (e.g., `backup --all-databases`).                     |
-| `--all-in-one`          | `-A`       | Backs up all databases in a single file (e.g., `backup --all-databases --single-file`). |
-| `--custom-name`         | ``         | Sets custom backup name for one time backup                                             |
-| `--help`                | `-h`       | Display help message and exit.                                                          |
-| `--version`             | `-V`       | Display version information and exit.                                                   |
+| Option                  | Short Flag | Description                                                                               |
+|-------------------------|------------|-------------------------------------------------------------------------------------------|
+| `pg-bkup`               | `bkup`     | CLI utility for managing PostgreSQL backups.                                              |
+| `backup`                |            | Perform a backup operation.                                                               |
+| `restore`               |            | Perform a restore operation.                                                              |
+| `migrate`               |            | Migrate a database from one instance to another.                                          |
+| `--storage`             | `-s`       | Storage type (`local`, `s3`, `ssh`, etc.). Default: `local`.                              |
+| `--file`                | `-f`       | File name for restoration.                                                                |
+| `--path`                |            | Path for storage (e.g., `/custom_path` for S3 or `/home/foo/backup` for SSH).             |
+| `--config`              | `-c`       | Configuration file for multi database backup. (e.g: `/backup/config.yaml`).               |
+| `--dbname`              | `-d`       | Database name.                                                                            |
+| `--port`                | `-p`       | Database port. Default: `5432`.                                                           |
+| `--disable-compression` |            | Disable compression for database backups.                                                 |
+| `--cron-expression`     | `-e`       | Cron expression for scheduled backups (e.g., `0 0 * * *` or `@daily`).                    |
+| `--all-databases`       | `-a`       | Backs up all databases separately (e.g., `backup --all-databases`).                       |
+| `--all-in-one`          | `-A`       | Backs up all databases in a single file (e.g., `backup --all-databases --single-file`).   |
+| `--exclude-db`          |            | Excludes databases from `--all-databases` backup (e.g., `--exclude-db _aiven,defaultdb`). |
+| `--custom-name`         | ``         | Sets custom backup name for one time backup                                               |
+| `--help`                | `-h`       | Display help message and exit.                                                            |
+| `--version`             | `-V`       | Display version information and exit.                                                     |
 
 ---
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -45,6 +45,8 @@ Backup, restore, and migration targets, schedules, and retention policies are co
 | `DB_USERNAME`                  | Required                             | Database username.                                                         |
 | `DB_PASSWORD`                  | Required                             | Database password.                                                         |
 | `DB_URL`                       | Optional                             | Database URL in JDBC URI format.                                           |
+| `DB_SSL_MODE`                  | Optional (default: `disable`)        | SSL mode for database connection (`disable`, `require`, `verify-full`...). |
+| `DB_AUTH_DATABASE`             | Optional (default: `postgres`)       | Authentication database used to establish the connection.                  |
 | `AWS_ACCESS_KEY`               | Required for S3 storage              | AWS S3 Access Key.                                                         |
 | `AWS_SECRET_KEY`               | Required for S3 storage              | AWS S3 Secret Key.                                                         |
 | `AWS_BUCKET_NAME`              | Required for S3 storage              | AWS S3 Bucket Name.                                                        |

--- a/pkg/backup.go
+++ b/pkg/backup.go
@@ -130,7 +130,18 @@ func backupAll(db *dbConfig, config *BackupConfig) {
 	if err != nil {
 		logger.Fatal("Error listing databases", "error", err)
 	}
-	logger.Info("Backing up all databases", "count", len(databases))
+	if len(config.excludeDatabases) > 0 {
+		filtered := []string{}
+		for _, name := range databases {
+			if !utils.Contains(config.excludeDatabases, name) {
+				filtered = append(filtered, name)
+			}
+		}
+		logger.Info("Databases after exclusion", "excluded", len(databases)-len(filtered), "remaining", len(filtered))
+		databases = filtered
+	} else {
+		logger.Info("Backing up all databases", "count", len(databases))
+	}
 	for _, dbName := range databases {
 		db.dbName = dbName
 		config.backupFileName = fmt.Sprintf("%s_%s.sql.gz", dbName, time.Now().Format("20060102_150405"))

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -238,6 +238,7 @@ func initBackupConfig(cmd *cobra.Command) *BackupConfig {
 	config.schemaOnly = schemaOnly
 	config.dataOnly = dataOnly
 	config.tables = tables
+	config.excludeDatabases, _ = cmd.Flags().GetStringSlice("exclude-db")
 	return &config
 }
 

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -82,6 +82,7 @@ type BackupConfig struct {
 	schemaOnly         bool
 	dataOnly           bool
 	tables             []string
+	excludeDatabases   []string
 }
 type FTPConfig struct {
 	host       string

--- a/utils/constant.go
+++ b/utils/constant.go
@@ -29,7 +29,8 @@ import "os"
 const RestoreExample = "restore --dbname database --file db_20231219_022941.sql.gz\n" +
 	"restore --dbname database --storage s3 --path /custom-path --file db_20231219_022941.sql.gz"
 const BackupExample = "backup --dbname database --disable-compression\n" +
-	"backup --dbname database --storage s3 --path /custom-path --disable-compression"
+	"backup --dbname database --storage s3 --path /custom-path --disable-compression\n" +
+	"backup --all-databases --exclude-db _aiven,defaultdb"
 
 const MainExample = "backup --dbname database --disable-compression\n" +
 	"backup --dbname database --storage s3 --path /custom-path\n" +

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -226,6 +226,16 @@ func GetIntEnv(envName string) int {
 	return ret
 }
 
+// Contains returns true if slice contains the given string
+func Contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
 func EnvWithDefault(envName string, defaultValue string) string {
 	value := os.Getenv(envName)
 	if value == "" {


### PR DESCRIPTION
### Add **--exclude-db** flag to backup command

  This PR introduces the **--exclude-db** flag for the **backup** command, allowing users to exclude specific databases when using **--all-databases**.

### Changes

  - Add **--exclude-db** flag (comma-separated) to the **backup** command
  - Add **excludeDatabases []string** field to **BackupConfig**
  - Filter excluded databases in **backupAll()** after listing, before iterating
  - Add **utils.Contains()** helper
  - Update CLI reference and **backup-all** how-to with usage example

  ### Usage

  pg-bkup backup --all-databases --exclude-db _aiven,defaultdb

  This is especially useful in managed PostgreSQL environments (e.g. Aiven) where system-level databases should not be included in backups.