### PR TITLE
feat: add multipart backup and restore support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,10 @@ AZURE_STORAGE_ACCOUNT_KEY=
 #GPG_PRIVATE_KEY=/config/private_key.asc
 #GPG_PASSPHRASE=Your strong passphrase
 
+## Multipart backup (split large backups into smaller files)
+#MULTIPART_ENABLED=false
+#MULTIPART_SIZE=100  # Size in MB for each part
+
 ## For multiple database backup on Docker or Docker in Swarm mode
 #BACKUP_CONFIG_FILE=/config/config.yaml
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ It is a lightweight, multi-architecture solution compatible with **Docker**, **D
     - SSH-compatible storage
     - Azure Blob storage
 
+- **Multipart Backup:**
+    - Split large backups into multiple smaller files
+    - Configurable chunk size for storage with file limits
+    - Works with all storage backends (local, S3, SSH, FTP, Azure)
+
 - **Data Security:**
     - Backups can be encrypted using **GPG** to ensure confidentiality.
 
@@ -167,6 +172,128 @@ docker run --rm --network your_network_name \
   -e "DB_USERNAME=username" \
   -e "DB_PASSWORD=password" \
   jkaninda/pg-bkup backup -d database_name --tables table1,table2
+```
+
+### Multipart Backup
+
+For large databases, you can split backup files into multiple smaller parts. This is useful for:
+- Uploading to storage with file size limits
+- Parallel uploads/downloads
+- Easier management of large backups
+
+#### Enable Multipart Backup
+
+Set the `MULTIPART_SIZE` environment variable (in MB) and use the `--multipart` flag:
+
+```shell
+docker run --rm --network your_network_name \
+  -v $PWD/backup:/backup/ \
+  -e "DB_HOST=dbhost" \
+  -e "DB_PORT=5432" \
+  -e "DB_USERNAME=username" \
+  -e "DB_PASSWORD=password" \
+  -e "MULTIPART_SIZE=100" \
+  jkaninda/pg-bkup backup -d database_name --multipart
+```
+
+Or enable via environment variable:
+
+```shell
+docker run --rm --network your_network_name \
+  -v $PWD/backup:/backup/ \
+  -e "DB_HOST=dbhost" \
+  -e "DB_PORT=5432" \
+  -e "DB_USERNAME=username" \
+  -e "DB_PASSWORD=password" \
+  -e "MULTIPART_ENABLED=true" \
+  -e "MULTIPART_SIZE=100" \
+  jkaninda/pg-bkup backup -d database_name
+```
+
+#### Restore from Multipart Backup
+
+Use the `--multipart` flag when restoring:
+
+```shell
+docker run --rm --network your_network_name \
+  -v $PWD/backup:/backup/ \
+  -e "DB_HOST=dbhost" \
+  -e "DB_PORT=5432" \
+  -e "DB_USERNAME=username" \
+  -e "DB_PASSWORD=password" \
+  jkaninda/pg-bkup restore -d database_name --multipart -f database_name_20240101_120000.sql.gz
+```
+
+Or enable via environment variable:
+
+```shell
+docker run --rm --network your_network_name \
+  -v $PWD/backup:/backup/ \
+  -e "DB_HOST=dbhost" \
+  -e "DB_PORT=5432" \
+  -e "DB_USERNAME=username" \
+  -e "DB_PASSWORD=password" \
+  -e "MULTIPART_ENABLED=true" \
+  jkaninda/pg-bkup restore -d database_name -f database_name_20240101_120000.sql.gz
+```
+
+**Docker Compose example for restore:**
+
+```yaml
+services:
+  pg-bkup-restore:
+    image: jkaninda/pg-bkup
+    command: restore -d database_name --multipart -f database_name_20240101_120000.sql.gz
+    environment:
+      - DB_HOST=postgres
+      - DB_USERNAME=user
+      - DB_PASSWORD=password
+    volumes:
+      - ./backup:/backup
+```
+
+> **Note:** Specify the base filename (without `.partXXX` extension). The tool will automatically find and merge all parts.
+
+#### Multipart with S3 Storage
+
+```shell
+# Backup with multipart to S3
+docker run --rm --network your_network_name \
+  -e "DB_HOST=dbhost" \
+  -e "DB_PORT=5432" \
+  -e "DB_USERNAME=username" \
+  -e "DB_PASSWORD=password" \
+  -e "AWS_S3_BUCKET_NAME=your-bucket" \
+  -e "AWS_S3_ENDPOINT=https://s3.amazonaws.com" \
+  -e "AWS_ACCESS_KEY=your-access-key" \
+  -e "AWS_SECRET_KEY=your-secret-key" \
+  -e "MULTIPART_SIZE=100" \
+  jkaninda/pg-bkup backup -d database_name --multipart --storage s3
+
+# Restore from multipart S3 backup (using flag)
+docker run --rm --network your_network_name \
+  -e "DB_HOST=dbhost" \
+  -e "DB_PORT=5432" \
+  -e "DB_USERNAME=username" \
+  -e "DB_PASSWORD=password" \
+  -e "AWS_S3_BUCKET_NAME=your-bucket" \
+  -e "AWS_S3_ENDPOINT=https://s3.amazonaws.com" \
+  -e "AWS_ACCESS_KEY=your-access-key" \
+  -e "AWS_SECRET_KEY=your-secret-key" \
+  jkaninda/pg-bkup restore -d database_name --multipart --storage s3 -f database_name_20240101_120000.sql.gz
+
+# Restore from multipart S3 backup (using environment variable)
+docker run --rm --network your_network_name \
+  -e "DB_HOST=dbhost" \
+  -e "DB_PORT=5432" \
+  -e "DB_USERNAME=username" \
+  -e "DB_PASSWORD=password" \
+  -e "AWS_S3_BUCKET_NAME=your-bucket" \
+  -e "AWS_S3_ENDPOINT=https://s3.amazonaws.com" \
+  -e "AWS_ACCESS_KEY=your-access-key" \
+  -e "AWS_SECRET_KEY=your-secret-key" \
+  -e "MULTIPART_ENABLED=true" \
+  jkaninda/pg-bkup restore -d database_name --storage s3 -f database_name_20240101_120000.sql.gz
 ```
 
 

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -58,4 +58,5 @@ func init() {
 	BackupCmd.PersistentFlags().Bool("schema-only", false, "Backup database schema only")
 	BackupCmd.PersistentFlags().Bool("data-only", false, "Backup database data only")
 	BackupCmd.PersistentFlags().StringSliceP("tables", "t", []string{}, "List of tables to include in the backup")
+	BackupCmd.PersistentFlags().Bool("multipart", false, "Split backup into multiple parts (requires MULTIPART_SIZE env)")
 }

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -50,5 +50,5 @@ func init() {
 	RestoreCmd.PersistentFlags().StringP("file", "f", "", "File name of database")
 	RestoreCmd.PersistentFlags().StringP("storage", "s", "local", "Define storage: local, s3, ssh, ftp")
 	RestoreCmd.PersistentFlags().StringP("path", "P", "", "AWS S3 path without file name. eg: /custom_path or ssh remote path `/home/foo/backup`")
-
+	RestoreCmd.PersistentFlags().Bool("multipart", false, "Restore from multipart backup files")
 }

--- a/pkg/azure.go
+++ b/pkg/azure.go
@@ -134,7 +134,11 @@ func azureRestore(db *dbConfig, conf *RestoreConfig) {
 		if partNum > 1 {
 			logger.Info("Downloaded multipart backup files from Azure", "parts", partNum-1)
 		} else {
-			logger.Fatal("No multipart files found", "base_file", conf.file)
+			logger.Info("No multipart parts found in Azure Blob storage, checking for base file...")
+			err := azureStorage.CopyFrom(conf.file)
+			if err != nil {
+				logger.Fatal("No multipart files or base file found in Azure Blob storage", "base_file", conf.file)
+			}
 		}
 	} else {
 		err = azureStorage.CopyFrom(conf.file)

--- a/pkg/azure.go
+++ b/pkg/azure.go
@@ -119,9 +119,28 @@ func azureRestore(db *dbConfig, conf *RestoreConfig) {
 		logger.Fatal("Error creating Azure Blob storage", "error", err)
 	}
 
-	err = azureStorage.CopyFrom(conf.file)
-	if err != nil {
-		logger.Fatal("Error downloading backup file", "error", err)
+	// If multipart is enabled, download all part files
+	if conf.multipart {
+		logger.Info("Downloading multipart backup files from Azure Blob storage...")
+		partNum := 1
+		for {
+			partFileName := fmt.Sprintf("%s.part%03d", conf.file, partNum)
+			err := azureStorage.CopyFrom(partFileName)
+			if err != nil {
+				break
+			}
+			partNum++
+		}
+		if partNum > 1 {
+			logger.Info("Downloaded multipart backup files from Azure", "parts", partNum-1)
+		} else {
+			logger.Fatal("No multipart files found", "base_file", conf.file)
+		}
+	} else {
+		err = azureStorage.CopyFrom(conf.file)
+		if err != nil {
+			logger.Fatal("Error downloading backup file", "error", err)
+		}
 	}
 	RestoreDatabase(db, conf)
 }

--- a/pkg/backup.go
+++ b/pkg/backup.go
@@ -36,6 +36,7 @@ import (
 	"github.com/jkaninda/pg-bkup/utils"
 	"github.com/robfig/cron/v3"
 	"github.com/spf13/cobra"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -377,28 +378,58 @@ func localBackup(db *dbConfig, config *BackupConfig) {
 		encryptBackup(config)
 		finalFileName = fmt.Sprintf("%s.%s", config.backupFileName, gpgExtension)
 	}
-	fileInfo, err := os.Stat(filepath.Join(tmpPath, finalFileName))
+
+	// Handle multipart split if enabled
+	filesToCopy, err := handleMultipartBackup(config, finalFileName)
 	if err != nil {
+		logger.Fatal("Error splitting backup file", "error", err)
+	}
+
+	fileInfo, err := os.Stat(filepath.Join(tmpPath, finalFileName))
+	if err != nil && len(filesToCopy) == 1 {
 		logger.Error("Error getting backup info", "error", err)
 	}
-	backupSize = fileInfo.Size()
+	if fileInfo != nil {
+		backupSize = fileInfo.Size()
+	}
+
 	localStorage := local.NewStorage(local.Config{
 		LocalPath:  tmpPath,
 		RemotePath: storagePath,
 	})
-	err = localStorage.Copy(finalFileName)
-	if err != nil {
-		logger.Fatal("Error copying backup file", "error", err)
+
+	// Copy all files (single file or multiple parts)
+	totalSize := backupSize
+	for _, fileName := range filesToCopy {
+		err = localStorage.Copy(fileName)
+		if err != nil {
+			logger.Fatal("Error copying backup file", "error", err)
+		}
+		if len(filesToCopy) > 1 {
+			partInfo, _ := os.Stat(filepath.Join(tmpPath, fileName))
+			if partInfo != nil {
+				totalSize += partInfo.Size()
+			}
+		}
 	}
 
 	duration := goutils.FormatDuration(time.Since(startTime), 0)
-	logger.Info("Backup file copied to local storage", "file", finalFileName, "destination", storagePath)
-	logger.Info("Backup completed", "file", finalFileName, "size", goutils.ConvertBytes(uint64(backupSize)), "duration", duration)
+	if len(filesToCopy) > 1 {
+		logger.Info("Backup files copied to local storage", "parts", len(filesToCopy), "destination", storagePath)
+		logger.Info("Backup completed", "parts", len(filesToCopy), "total_size", goutils.ConvertBytes(uint64(totalSize)), "duration", duration)
+	} else {
+		logger.Info("Backup file copied to local storage", "file", finalFileName, "destination", storagePath)
+		logger.Info("Backup completed", "file", finalFileName, "size", goutils.ConvertBytes(uint64(backupSize)), "duration", duration)
+	}
 
 	// Send notification
+	notificationFile := finalFileName
+	if len(filesToCopy) > 1 {
+		notificationFile = fmt.Sprintf("%s (%d parts)", finalFileName, len(filesToCopy))
+	}
 	utils.NotifySuccess(&utils.NotificationData{
-		File:           finalFileName,
-		BackupSize:     goutils.ConvertBytes(uint64(backupSize)),
+		File:           notificationFile,
+		BackupSize:     goutils.ConvertBytes(uint64(totalSize)),
 		Database:       db.dbName,
 		Storage:        string(config.storage),
 		BackupLocation: filepath.Join(storagePath, finalFileName),
@@ -518,4 +549,76 @@ func recoverMode(err error, msg string) {
 		}
 	}
 
+}
+
+// splitFile splits a file into multiple parts of specified chunk size
+// Returns the list of part filenames
+func splitFile(filePath string, chunkSize int64) ([]string, error) {
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat file: %w", err)
+	}
+
+	if fileInfo.Size() <= chunkSize {
+		return nil, nil
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	var parts []string
+	baseName := filepath.Base(filePath)
+	dir := filepath.Dir(filePath)
+	partNum := 1
+	buffer := make([]byte, chunkSize)
+
+	for {
+		n, err := file.Read(buffer)
+		if err != nil && err != io.EOF {
+			return nil, fmt.Errorf("failed to read file: %w", err)
+		}
+		if n == 0 {
+			break
+		}
+
+		partFileName := fmt.Sprintf("%s.part%03d", baseName, partNum)
+		partPath := filepath.Join(dir, partFileName)
+
+		if err := os.WriteFile(partPath, buffer[:n], 0644); err != nil {
+			return nil, fmt.Errorf("failed to write part file: %w", err)
+		}
+
+		parts = append(parts, partFileName)
+		partNum++
+	}
+
+	logger.Info("File split into parts", "parts", len(parts), "base_name", baseName)
+	return parts, nil
+}
+
+// handleMultipartBackup handles multipart backup splitting if enabled
+func handleMultipartBackup(config *BackupConfig, fileName string) ([]string, error) {
+	if !config.multipart || config.multipartSize <= 0 {
+		return []string{fileName}, nil
+	}
+
+	filePath := filepath.Join(tmpPath, fileName)
+	parts, err := splitFile(filePath, config.multipartSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to split file: %w", err)
+	}
+
+	if len(parts) == 0 {
+		return []string{fileName}, nil
+	}
+
+	// Remove original file after successful split
+	if err := os.Remove(filePath); err != nil {
+		logger.Warn("Failed to remove original file after split", "error", err)
+	}
+
+	return parts, nil
 }

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -238,6 +238,23 @@ func initBackupConfig(cmd *cobra.Command) *BackupConfig {
 	config.schemaOnly = schemaOnly
 	config.dataOnly = dataOnly
 	config.tables = tables
+
+	multipart := utils.FlagGetBool(cmd, "multipart") || os.Getenv("MULTIPART_ENABLED") == "true"
+	multipartSizeStr := os.Getenv("MULTIPART_SIZE")
+	var multipartSize int64 = 0
+	if multipartSizeStr != "" {
+		size, err := strconv.ParseInt(multipartSizeStr, 10, 64)
+		if err == nil {
+			multipartSize = size * 1024 * 1024
+		} else {
+			logger.Warn("Invalid MULTIPART_SIZE value, using default (no multipart)")
+		}
+	}
+	if multipartSize > 0 {
+		multipart = true
+	}
+	config.multipart = multipart
+	config.multipartSize = multipartSize
 	return &config
 }
 
@@ -250,6 +267,7 @@ type RestoreConfig struct {
 	usingKey   bool
 	passphrase string
 	privateKey string
+	multipart  bool
 }
 
 func initRestoreConfig(cmd *cobra.Command) *RestoreConfig {
@@ -280,6 +298,8 @@ func initRestoreConfig(cmd *cobra.Command) *RestoreConfig {
 	rConfig.passphrase = passphrase
 	rConfig.usingKey = usingKey
 	rConfig.privateKey = privateKeyFile
+
+	rConfig.multipart = utils.FlagGetBool(cmd, "multipart") || os.Getenv("MULTIPART_ENABLED") == "true"
 	return &rConfig
 }
 func initTargetDbConfig() *targetDbConfig {

--- a/pkg/remote.go
+++ b/pkg/remote.go
@@ -147,7 +147,11 @@ func remoteRestore(db *dbConfig, conf *RestoreConfig) {
 		if partNum > 1 {
 			logger.Info("Downloaded multipart backup files from remote", "parts", partNum-1)
 		} else {
-			logger.Fatal("No multipart files found", "base_file", conf.file)
+			logger.Info("No multipart parts found on remote server, checking for base file...")
+			err := sshStorage.CopyFrom(conf.file)
+			if err != nil {
+				logger.Fatal("No multipart files or base file found on remote server", "base_file", conf.file)
+			}
 		}
 	} else {
 		err = sshStorage.CopyFrom(conf.file)
@@ -187,7 +191,11 @@ func ftpRestore(db *dbConfig, conf *RestoreConfig) {
 		if partNum > 1 {
 			logger.Info("Downloaded multipart backup files from FTP", "parts", partNum-1)
 		} else {
-			logger.Fatal("No multipart files found", "base_file", conf.file)
+			logger.Info("No multipart parts found on FTP server, checking for base file...")
+			err := ftpStorage.CopyFrom(conf.file)
+			if err != nil {
+				logger.Fatal("No multipart files or base file found on FTP server", "base_file", conf.file)
+			}
 		}
 	} else {
 		err = ftpStorage.CopyFrom(conf.file)

--- a/pkg/remote.go
+++ b/pkg/remote.go
@@ -131,9 +131,29 @@ func remoteRestore(db *dbConfig, conf *RestoreConfig) {
 	if err != nil {
 		logger.Fatal("Error creating SSH storage", "error", err)
 	}
-	err = sshStorage.CopyFrom(conf.file)
-	if err != nil {
-		logger.Fatal("Error uploading backup file", "error", err)
+
+	// If multipart is enabled, download all part files
+	if conf.multipart {
+		logger.Info("Downloading multipart backup files from remote server...")
+		partNum := 1
+		for {
+			partFileName := fmt.Sprintf("%s.part%03d", conf.file, partNum)
+			err := sshStorage.CopyFrom(partFileName)
+			if err != nil {
+				break
+			}
+			partNum++
+		}
+		if partNum > 1 {
+			logger.Info("Downloaded multipart backup files from remote", "parts", partNum-1)
+		} else {
+			logger.Fatal("No multipart files found", "base_file", conf.file)
+		}
+	} else {
+		err = sshStorage.CopyFrom(conf.file)
+		if err != nil {
+			logger.Fatal("Error downloading backup file", "error", err)
+		}
 	}
 	RestoreDatabase(db, conf)
 }
@@ -149,11 +169,31 @@ func ftpRestore(db *dbConfig, conf *RestoreConfig) {
 		LocalPath:  tmpPath,
 	})
 	if err != nil {
-		logger.Fatal("Error creating SSH storage", "error", err)
+		logger.Fatal("Error creating FTP storage", "error", err)
 	}
-	err = ftpStorage.CopyFrom(conf.file)
-	if err != nil {
-		logger.Fatal("Error uploading backup file", "error", err)
+
+	// If multipart is enabled, download all part files
+	if conf.multipart {
+		logger.Info("Downloading multipart backup files from FTP server...")
+		partNum := 1
+		for {
+			partFileName := fmt.Sprintf("%s.part%03d", conf.file, partNum)
+			err := ftpStorage.CopyFrom(partFileName)
+			if err != nil {
+				break
+			}
+			partNum++
+		}
+		if partNum > 1 {
+			logger.Info("Downloaded multipart backup files from FTP", "parts", partNum-1)
+		} else {
+			logger.Fatal("No multipart files found", "base_file", conf.file)
+		}
+	} else {
+		err = ftpStorage.CopyFrom(conf.file)
+		if err != nil {
+			logger.Fatal("Error downloading backup file", "error", err)
+		}
 	}
 	RestoreDatabase(db, conf)
 }

--- a/pkg/restore.go
+++ b/pkg/restore.go
@@ -90,7 +90,11 @@ func localRestore(dbConf *dbConfig, restoreConf *RestoreConfig) {
 		if partNum > 1 {
 			logger.Info("Downloaded multipart backup files", "parts", partNum-1)
 		} else {
-			logger.Fatal("No multipart files found", "base_file", fileName)
+			logger.Info("No multipart parts found, checking for base file...")
+			err := localStorage.CopyFrom(fileName)
+			if err != nil {
+				logger.Fatal("No multipart files or base file found", "base_file", fileName)
+			}
 		}
 	} else {
 		err := localStorage.CopyFrom(fileName)

--- a/pkg/restore.go
+++ b/pkg/restore.go
@@ -31,13 +31,17 @@ import (
 	"github.com/jkaninda/logger"
 	"github.com/jkaninda/pg-bkup/utils"
 	"github.com/spf13/cobra"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"sort"
 )
 
 func StartRestore(cmd *cobra.Command) {
 	intro()
+	deleteTemp()
 	dbConf = initDbConfig(cmd)
 	restoreConf := initRestoreConfig(cmd)
 
@@ -68,9 +72,31 @@ func localRestore(dbConf *dbConfig, restoreConf *RestoreConfig) {
 		RemotePath: basePath,
 		LocalPath:  tmpPath,
 	})
-	err := localStorage.CopyFrom(fileName)
-	if err != nil {
-		logger.Fatal("Error copying backup file", "error", err)
+
+	// If multipart is enabled, download all part files
+	if restoreConf.multipart {
+		logger.Info("Downloading multipart backup files...")
+		// Download all part files (filename.part001, filename.part002, etc.)
+		partNum := 1
+		for {
+			partFileName := fmt.Sprintf("%s.part%03d", fileName, partNum)
+			err := localStorage.CopyFrom(partFileName)
+			if err != nil {
+				// No more parts found
+				break
+			}
+			partNum++
+		}
+		if partNum > 1 {
+			logger.Info("Downloaded multipart backup files", "parts", partNum-1)
+		} else {
+			logger.Fatal("No multipart files found", "base_file", fileName)
+		}
+	} else {
+		err := localStorage.CopyFrom(fileName)
+		if err != nil {
+			logger.Fatal("Error copying backup file", "error", err)
+		}
 	}
 	RestoreDatabase(dbConf, restoreConf)
 
@@ -80,6 +106,15 @@ func localRestore(dbConf *dbConfig, restoreConf *RestoreConfig) {
 func RestoreDatabase(db *dbConfig, conf *RestoreConfig) {
 	if conf.file == "" {
 		logger.Fatal("Error, file required")
+	}
+
+	// Handle multipart restore if enabled
+	if conf.multipart {
+		restorationFile, err := handleMultipartRestore(conf)
+		if err != nil {
+			logger.Fatal("Error handling multipart restore", "error", err)
+		}
+		conf.file = filepath.Base(restorationFile)
 	}
 
 	filePath := filepath.Join(tmpPath, conf.file)
@@ -151,4 +186,93 @@ func restoreDatabaseFile(db *dbConfig, restorationFile string) {
 
 	logger.Info("Database has been restored successfully.")
 	deleteTemp()
+}
+
+// findPartFiles finds all part files for a given base filename
+// Only matches files with pattern: filename.partNNN (where NNN is 3 digits)
+// Also verifies files are non-empty (S3 library may create empty files on failed downloads)
+func findPartFiles(tmpPath, baseFileName string) ([]string, error) {
+	var partFiles []string
+	entries, err := os.ReadDir(tmpPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read temp directory: %w", err)
+	}
+
+	partPattern := regexp.MustCompile(`^` + regexp.QuoteMeta(baseFileName) + `\.part\d{3}$`)
+	for _, entry := range entries {
+		if !entry.IsDir() && partPattern.MatchString(entry.Name()) {
+			filePath := filepath.Join(tmpPath, entry.Name())
+			info, err := os.Stat(filePath)
+			if err != nil {
+				continue
+			}
+			if info.Size() == 0 {
+				os.Remove(filePath)
+				continue
+			}
+			partFiles = append(partFiles, entry.Name())
+		}
+	}
+
+	sort.Strings(partFiles)
+	return partFiles, nil
+}
+
+// mergePartFiles merges multiple part files into a single file
+// Returns the path to the merged file
+func mergePartFiles(tmpPath, baseFileName string, partFiles []string) (string, error) {
+	mergedFilePath := filepath.Join(tmpPath, baseFileName)
+	mergedFile, err := os.Create(mergedFilePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to create merged file: %w", err)
+	}
+	defer mergedFile.Close()
+
+	for _, partFile := range partFiles {
+		partPath := filepath.Join(tmpPath, partFile)
+		partData, err := os.Open(partPath)
+		if err != nil {
+			return "", fmt.Errorf("failed to open part file %s: %w", partFile, err)
+		}
+
+		_, err = io.Copy(mergedFile, partData)
+		partData.Close()
+		if err != nil {
+			return "", fmt.Errorf("failed to copy part file %s: %w", partFile, err)
+		}
+	}
+
+	logger.Info("Multipart files merged", "parts", len(partFiles), "output", baseFileName)
+	return mergedFilePath, nil
+}
+
+// handleMultipartRestore handles merging multipart files before restore
+// Returns the path to the file to restore
+func handleMultipartRestore(conf *RestoreConfig) (string, error) {
+	baseFileName := conf.file
+
+	// Check if this is a multipart restore (user specified multipart flag)
+	// or auto-detect by looking for part files
+	partFiles, err := findPartFiles(tmpPath, baseFileName)
+	if err != nil {
+		return "", err
+	}
+
+	if len(partFiles) == 0 {
+		// No part files found, return the original file path
+		return filepath.Join(tmpPath, baseFileName), nil
+	}
+
+	logger.Info("Found multipart backup files", "parts", len(partFiles))
+
+	// Merge all parts
+	mergedPath, err := mergePartFiles(tmpPath, baseFileName, partFiles)
+	if err != nil {
+		return "", err
+	}
+
+	// Update the conf.file to point to merged file
+	conf.file = baseFileName
+
+	return mergedPath, nil
 }

--- a/pkg/s3.go
+++ b/pkg/s3.go
@@ -166,7 +166,11 @@ func s3Restore(db *dbConfig, conf *RestoreConfig) {
 		if partNum > 1 {
 			logger.Info("Downloaded multipart backup files from S3", "parts", partNum-1)
 		} else {
-			logger.Fatal("No multipart files found", "base_file", conf.file)
+			logger.Info("No multipart parts found in S3, checking for base file...")
+			err := s3Storage.CopyFrom(conf.file)
+			if err != nil {
+				logger.Fatal("No multipart files or base file found in S3", "base_file", conf.file)
+			}
 		}
 	} else {
 		err = s3Storage.CopyFrom(conf.file)

--- a/pkg/s3.go
+++ b/pkg/s3.go
@@ -50,6 +50,13 @@ func s3Backup(db *dbConfig, config *BackupConfig) {
 		encryptBackup(config)
 		finalFileName = fmt.Sprintf("%s.%s", config.backupFileName, "gpg")
 	}
+
+	// Handle multipart split if enabled
+	filesToUpload, err := handleMultipartBackup(config, finalFileName)
+	if err != nil {
+		logger.Fatal("Error splitting backup file", "error", err)
+	}
+
 	logger.Info("Uploading backup archive to remote storage S3 ... ")
 	awsConfig := initAWSConfig()
 	if config.remotePath == "" {
@@ -70,23 +77,24 @@ func s3Backup(db *dbConfig, config *BackupConfig) {
 	if err != nil {
 		logger.Fatal("Error creating s3 storage", "error", err)
 	}
-	err = s3Storage.Copy(finalFileName)
-	if err != nil {
-		logger.Fatal("Error uploading backup file", "error", err)
-	}
-	// Get backup info
-	fileInfo, err := os.Stat(filepath.Join(tmpPath, finalFileName))
-	if err != nil {
-		logger.Error("Error getting backup info", "error", err)
-	}
-	backupSize = fileInfo.Size()
 
-	// Delete backup file from tmp folder
-	err = utils.DeleteFile(filepath.Join(tmpPath, config.backupFileName))
-	if err != nil {
-		fmt.Println("Error deleting file: ", err)
-
+	// Upload all files (single file or multiple parts)
+	totalSize := int64(0)
+	for _, fileName := range filesToUpload {
+		err = s3Storage.Copy(fileName)
+		if err != nil {
+			logger.Fatal("Error uploading backup file", "error", err)
+		}
+		partInfo, _ := os.Stat(filepath.Join(tmpPath, fileName))
+		if partInfo != nil {
+			totalSize += partInfo.Size()
+		}
 	}
+
+	if totalSize > 0 {
+		backupSize = totalSize
+	}
+
 	// Delete old backup
 	if config.prune {
 		err := s3Storage.Prune(config.backupRetention)
@@ -96,11 +104,21 @@ func s3Backup(db *dbConfig, config *BackupConfig) {
 	}
 
 	duration := goutils.FormatDuration(time.Since(startTime), 2)
-	logger.Info("Backup file uploaded to  S3 storage", "file", finalFileName, "destination", storagePath)
-	logger.Info("Backup completed", "file", finalFileName, "size", goutils.ConvertBytes(uint64(backupSize)), "duration", duration)
+	if len(filesToUpload) > 1 {
+		logger.Info("Backup files uploaded to S3 storage", "parts", len(filesToUpload), "destination", config.remotePath)
+		logger.Info("Backup completed", "parts", len(filesToUpload), "total_size", goutils.ConvertBytes(uint64(backupSize)), "duration", duration)
+	} else {
+		logger.Info("Backup file uploaded to  S3 storage", "file", finalFileName, "destination", storagePath)
+		logger.Info("Backup completed", "file", finalFileName, "size", goutils.ConvertBytes(uint64(backupSize)), "duration", duration)
+	}
+
 	// Send notification
+	notificationFile := finalFileName
+	if len(filesToUpload) > 1 {
+		notificationFile = fmt.Sprintf("%s (%d parts)", finalFileName, len(filesToUpload))
+	}
 	utils.NotifySuccess(&utils.NotificationData{
-		File:           finalFileName,
+		File:           notificationFile,
 		BackupSize:     goutils.ConvertBytes(uint64(backupSize)),
 		Database:       db.dbName,
 		Storage:        string(config.storage),
@@ -132,9 +150,29 @@ func s3Restore(db *dbConfig, conf *RestoreConfig) {
 	if err != nil {
 		logger.Fatal("Error creating s3 storage", "error", err)
 	}
-	err = s3Storage.CopyFrom(conf.file)
-	if err != nil {
-		logger.Fatal("Error download file from S3 storage", "error", err)
+
+	// If multipart is enabled, download all part files
+	if conf.multipart {
+		logger.Info("Downloading multipart backup files from S3...")
+		partNum := 1
+		for {
+			partFileName := fmt.Sprintf("%s.part%03d", conf.file, partNum)
+			err := s3Storage.CopyFrom(partFileName)
+			if err != nil {
+				break
+			}
+			partNum++
+		}
+		if partNum > 1 {
+			logger.Info("Downloaded multipart backup files from S3", "parts", partNum-1)
+		} else {
+			logger.Fatal("No multipart files found", "base_file", conf.file)
+		}
+	} else {
+		err = s3Storage.CopyFrom(conf.file)
+		if err != nil {
+			logger.Fatal("Error download file from S3 storage", "error", err)
+		}
 	}
 	RestoreDatabase(db, conf)
 }

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -82,6 +82,14 @@ type BackupConfig struct {
 	schemaOnly         bool
 	dataOnly           bool
 	tables             []string
+	multipart          bool
+	multipartSize      int64
+}
+
+type MultipartConfig struct {
+	enabled    bool
+	chunkSize  int64
+	filePrefix string
 }
 type FTPConfig struct {
 	host       string


### PR DESCRIPTION
Add ability to split large backups into multiple smaller files with configurable chunk size. Supports --multipart flag and MULTIPART_ENABLED/MULTIPART_SIZE env vars. Works with all storage backends (local, S3, SSH, FTP, Azure).